### PR TITLE
refactor(domain): Classify common domain interfaces as Shared Kernel

### DIFF
--- a/CatalogService/src/main/java/es/penkatur/backend/catalog/domain/Catalog.java
+++ b/CatalogService/src/main/java/es/penkatur/backend/catalog/domain/Catalog.java
@@ -1,6 +1,6 @@
 package es.penkatur.backend.catalog.domain;
 
-import es.penkatur.backend.common.domain.UUIDBaseModel;
+import es.penkatur.backend.sharedkernel.domain.UUIDBaseModel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;

--- a/CatalogService/src/main/java/es/penkatur/backend/sharedkernel/domain/BaseModel.java
+++ b/CatalogService/src/main/java/es/penkatur/backend/sharedkernel/domain/BaseModel.java
@@ -1,4 +1,4 @@
-package es.penkatur.backend.common.domain;
+package es.penkatur.backend.sharedkernel.domain;
 
 import java.time.Instant;
 

--- a/CatalogService/src/main/java/es/penkatur/backend/sharedkernel/domain/UUIDBaseModel.java
+++ b/CatalogService/src/main/java/es/penkatur/backend/sharedkernel/domain/UUIDBaseModel.java
@@ -1,4 +1,4 @@
-package es.penkatur.backend.common.domain;
+package es.penkatur.backend.sharedkernel.domain;
 
 import java.util.UUID;
 

--- a/CatalogService/src/main/java/es/penkatur/backend/tag/domain/Tag.java
+++ b/CatalogService/src/main/java/es/penkatur/backend/tag/domain/Tag.java
@@ -1,5 +1,6 @@
 package es.penkatur.backend.tag.domain;
 
+import es.penkatur.backend.sharedkernel.domain.UUIDBaseModel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -10,7 +11,7 @@ import java.util.UUID;
 
 @Builder
 @Getter
-public class Tag {
+public class Tag implements UUIDBaseModel {
 
     @NonNull
     private UUID id;
@@ -38,6 +39,7 @@ public class Tag {
         this.color = color;
     }
 
+    @Override
     public void changeUpdatedAt(Instant updatedAt) {
         if (updatedAt == null)
             throw new IllegalArgumentException("Update date cannot be null");


### PR DESCRIPTION
Moves two domain interfaces from `common.domain` to `sharedkernel.domain` to reflect their role as part of the explicitly shared domain model (DDD Shared Kernel).